### PR TITLE
Discover session poc

### DIFF
--- a/src/platform/packages/shared/content-management/content_insights/content_insights_public/src/components/views_stats/views_stats.tsx
+++ b/src/platform/packages/shared/content-management/content_insights/content_insights_public/src/components/views_stats/views_stats.tsx
@@ -89,7 +89,7 @@ const NoViewsTip = () => {
         <>
           <FormattedMessage
             id="contentManagement.contentEditor.viewsStats.noViewsTip"
-            defaultMessage="Views are counted every time someone opens a dashboard"
+            defaultMessage="Views are counted every time someone opens a Discover session"
           />
           {isKibanaVersioningEnabled && (
             <>

--- a/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_top_nav_links.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/top_nav/use_top_nav_links.tsx
@@ -149,6 +149,7 @@ export const useTopNavLinks = ({
       if (!defaultMenu?.openItem?.disabled) {
         const openSearchMenuItem = getOpenSearchAppMenuItem({
           onOpenSavedSearch: state.actions.onOpenSavedSearch,
+          services,
         });
         items.push(openSearchMenuItem);
       }

--- a/src/platform/plugins/shared/discover/server/capabilities_provider.ts
+++ b/src/platform/plugins/shared/discover/server/capabilities_provider.ts
@@ -13,4 +13,6 @@ export const capabilitiesProvider = () => ({
     createShortUrl: true,
     save: true,
   },
+  // Capability used to guard Content Insights routes (analogous to dashboardUsageStats)
+  discoverUsageStats: { show: true },
 });

--- a/src/platform/plugins/shared/saved_objects_finder/public/finder/saved_object_finder.tsx
+++ b/src/platform/plugins/shared/saved_objects_finder/public/finder/saved_object_finder.tsx
@@ -85,6 +85,8 @@ interface BaseSavedObjectFinder {
   children?: ReactElement | ReactElement[];
   helpText?: string;
   getTooltipText?: (item: SavedObjectFinderItem) => string | undefined;
+  /** Optional additional columns appended to the right (POC extension) */
+  extraColumns?: Array<EuiTableFieldDataColumnType<SavedObjectFinderItem>>;
 }
 
 interface SavedObjectFinderFixedPage extends BaseSavedObjectFinder {
@@ -104,12 +106,13 @@ class SavedObjectFinderUiClass extends React.Component<
   SavedObjectFinderState
 > {
   public static propTypes = {
-    onChoose: PropTypes.func,
+  onChoose: PropTypes.func,
     noItemsMessage: PropTypes.node,
     savedObjectMetaData: PropTypes.array.isRequired,
     initialPageSize: PropTypes.oneOf([5, 10, 15, 25]),
     fixedPageSize: PropTypes.number,
     showFilter: PropTypes.bool,
+  extraColumns: PropTypes.array,
   };
   private isComponentMounted: boolean = false;
 
@@ -278,7 +281,7 @@ class SavedObjectFinderUiClass extends React.Component<
             },
           }
         : undefined;
-    const columns: Array<EuiTableFieldDataColumnType<SavedObjectFinderItem>> = [
+  let columns: Array<EuiTableFieldDataColumnType<SavedObjectFinderItem>> = [
       ...(typeColumn ? [typeColumn] : []),
       {
         field: 'title',
@@ -339,6 +342,9 @@ class SavedObjectFinderUiClass extends React.Component<
       },
       ...(tagColumn ? [tagColumn] : []),
     ];
+    if (this.props.extraColumns?.length) {
+      columns = [...columns, ...this.props.extraColumns];
+    }
     const pagination = {
       initialPageSize: !!this.props.fixedPageSize ? this.props.fixedPageSize : pageSize ?? 10,
       pageSize: !!this.props.fixedPageSize ? undefined : pageSize,

--- a/src/platform/plugins/shared/saved_search/server/content_management/saved_search_storage.ts
+++ b/src/platform/plugins/shared/saved_search/server/content_management/saved_search_storage.ts
@@ -49,6 +49,9 @@ export class SavedSearchStorage extends SOContentStorage<SavedSearchCrudTypes> {
         'density',
         'visContext',
         'tabs',
+  // meta fields (stored automatically on the saved object, surfaced through content mgmt item)
+  'createdBy',
+  'updatedBy',
       ],
       logger,
       throwOnResultValidationError,

--- a/x-pack/platform/plugins/shared/features/server/oss_features.ts
+++ b/x-pack/platform/plugins/shared/features/server/oss_features.ts
@@ -136,7 +136,6 @@ export const buildOSSFeatures = ({
             read: [],
           },
           ui: ['save'],
-          api: ['manage_advanced_settings'],
         },
         read: {
           app: ['kibana'],
@@ -353,12 +352,10 @@ const getBaseDiscoverFeature = ({
   includeReporting: boolean;
   version: 'v1' | 'v2';
 }): Omit<KibanaFeatureConfig, 'id' | 'order'> => {
-  const apiAllPrivileges = ['fileUpload:analyzeFile'];
+  const apiAllPrivileges = ['fileUpload:analyzeFile', 'bulkGetUserProfiles', 'discoverUsageStats'];
   const savedObjectAllPrivileges = ['search'];
   const uiAllPrivileges = ['show', 'save'];
-  // Include user profiles & content insights stats collection (views) for Discover sessions
   const apiReadPrivileges = ['bulkGetUserProfiles', 'discoverUsageStats'];
-  apiAllPrivileges.push('bulkGetUserProfiles', 'discoverUsageStats');
   const savedObjectReadPrivileges = ['index-pattern', 'search'];
 
   if (version === 'v1') {

--- a/x-pack/platform/plugins/shared/features/server/oss_features.ts
+++ b/x-pack/platform/plugins/shared/features/server/oss_features.ts
@@ -356,7 +356,9 @@ const getBaseDiscoverFeature = ({
   const apiAllPrivileges = ['fileUpload:analyzeFile'];
   const savedObjectAllPrivileges = ['search'];
   const uiAllPrivileges = ['show', 'save'];
-  const apiReadPrivileges = [];
+  // Include user profiles & content insights stats collection (views) for Discover sessions
+  const apiReadPrivileges = ['bulkGetUserProfiles', 'discoverUsageStats'];
+  apiAllPrivileges.push('bulkGetUserProfiles', 'discoverUsageStats');
   const savedObjectReadPrivileges = ['index-pattern', 'search'];
 
   if (version === 'v1') {


### PR DESCRIPTION
### Adds usage insights and metadata to the “Open Discover session” flyout:

Short video show-casing it:

https://github.com/user-attachments/assets/9d1f86b3-60bb-4b25-99a9-1fb741d22901

- New Details pane showing:
  - Creator (user profile card) and activity (created / last updated)
  - Views (last 90 days) chart via Content Insights
  - ES|QL query snippet (syntax‑highlighted + copy) for text-based sessions (with raw search source fallback)
- Inline selection (arrow icon) to preview details without closing the flyout
- Clicking a title opens the session and tracks a view

### Server / platform changes:

- Registers Content Insights domain discover (mirrors dashboard)
- Adds [discoverUsageStats] capability & privileges; exposes [bulkGetUserProfiles]
- Allows [createdBy] / [updatedBy] meta fields for Discover Sessions

### Checklist

- [ ]  Text follows EUI writing guidelines, sentence case, and i18n added for all new labels
- [ ]  Documentation (short blurb in Discover docs + dev docs for capability) pending
- [ ] Tests: add functional tests (views tracking increment, ES|QL extraction), unit tests for meta parsing (TODO)
- [ ] No plugin config key changes
- [ ] No breaking HTTP API changes (routes gated by new capability only)
- [ ] Run Flaky Test Runner after adding tests
- [ ] Release Notes section (below) & release_note:feature label to be added
- [ ] Backport labels to be decided after review
- [ ] The "Details" should open in Expandable flyout once ready
- [ ] Add ⭐ feature

### Identify risks

- Views chart depends on Content Insights ingestion: risk of silent failure if capability misconfigured (mitigate with added capability + server registration parity with dashboard).
- ES|QL query parsing is heuristic; malformed searchSource could fail silently (mitigate with fallback raw snippet and guarded try/catch).
- Added privileges ([discoverUsageStats], [bulkGetUserProfiles]) expand surface area; misconfiguration could expose minor internal usage endpoints (mitigate via capability gating and existing privilege model).

### Release Notes
Discover: Added session insights (views, creator, ES|QL query preview) to the Open Discover session flyout.